### PR TITLE
feature/IN-630: Updates to oauth provider codebase

### DIFF
--- a/lib/controller/authorization.js
+++ b/lib/controller/authorization.js
@@ -131,14 +131,17 @@ module.exports = function(req, res, next) {
     function(err) {
         if (err) response.error(req, res, err, redirectUri);
         else {
-            if (req.method == 'GET')
-                req.oauth2.decision(req, res, client, scope, user, redirectUri);
-            else if (grantType == 'authorization_code')
+            if (req.method == 'GET' && req.oauth2.model.client.needDecisionConfirmation(client))
+                req.oauth2.decision(req, res, next, client, scope, user, redirectUri);
+            else {
+              req.body['decision'] = 1;
+              if (grantType == 'authorization_code')
                 authorization.code(req, res, client, scope, user, redirectUri);
-            else if (grantType == 'implicit')
+              else if (grantType == 'implicit')
                 authorization.implicit(req, res, client, scope, user, redirectUri);
-            else
+              else
                 response.error(req, res, new error.invalidRequest('Wrong request method'), redirectUri);
+            }
         }
     });
 };

--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -83,6 +83,21 @@ module.exports = function(oauth2, client, refresh_token, scope, pCb) {
                     }
                 });
             }
+        },
+        //Refresh the refreshToken
+        function(cb) {
+          if(refreshToken) {
+            oauth2.model.refreshToken.refresh(refreshToken['token'], function(err) {
+              if (err)
+                cb(new error.serverError('Failed to refresh refreshToken'));
+              else {
+                oauth2.logger.debug('Refresh token refreshed: ', accessTokenValue);
+                cb();
+              }
+            });
+          } else {
+            cb(new error.serverError('Failed to call refreshToken::refresh method'));
+          }
         }
     ],
     function(err) {

--- a/lib/model/client.js
+++ b/lib/model/client.js
@@ -121,3 +121,16 @@ module.exports.transformScope = function(scope) {
 };
 
 
+/**
+ * Checks if decision page needs to be shown for user
+ *
+ * @param client {Object} Client object
+ */
+module.exports.needDecisionConfirmation = function(client) {
+  /**
+   * For example:
+   *
+   */
+  throw new error.serverError('Client model method "needDecisionConfirmation" is not implemented');
+};
+

--- a/lib/model/refreshToken.js
+++ b/lib/model/refreshToken.js
@@ -42,6 +42,11 @@ module.exports.getScope = function(refreshToken) {
     throw new error.serverError('RefreshToken model method "getScope" is not implemented');
 };
 
+
+module.exports.refresh = function(token, cb) {
+  throw new error.serverError('RefreshToken model method "refresh" is not implemented');
+};
+
 /**
  * Fetches refreshToken object by token
  * Should be implemented with server logic

--- a/lib/util/response.js
+++ b/lib/util/response.js
@@ -19,12 +19,16 @@ function redirect(req, res, redirectUri) {
 
 module.exports.error = function(req, res, err, redirectUri) {
     // Transform unknown error
+  if(err.code === 'invalid_grant') {
+    req.oauth2.logger['debug']('Exception caught (Refresh Token incalid or expired. User to re-login.)', err.stack);
+  } else {
     if (!(err instanceof error.oauth2)) {
-        req.oauth2.logger.error(err.stack);
-        err = new error.serverError('Uncaught exception');
+      req.oauth2.logger.error(err.stack);
+      err = new error.serverError('Uncaught exception');
     }
     else
-        req.oauth2.logger[err.logLevel]('Exception caught', err.stack);
+      req.oauth2.logger[err.logLevel]('Exception caught', err.stack);
+  }
 
     if (redirectUri) {
         var obj = {


### PR DESCRIPTION
The updates have been done for the following 2 reasons:
1. Include the option of skipping the consent screen: For a particluar tenant, the user consent screen has been designed to be optional. This helps in cases like the  Rails tenant where an explicit tenant is not really required. Hence, this parameter has been implemented as a client level parameter which can be skipped if the flag is set to "true"
2. Refresh token timeout reset: To implement session expiry, if the refresh token is not yet expired, then the timeout is refreshed to its original value to keep the session alive and expire only on idle timeout.
