### PR TITLE
IN-649: Update oauth20-provider package to use customizable ttl for access_token

### DIFF
--- a/lib/controller/authorization/implicit.js
+++ b/lib/controller/authorization/implicit.js
@@ -9,7 +9,8 @@ var
 module.exports = function(req, res, client, scope, user, redirectUri) {
 
     var
-        accessTokenValue;
+        accessTokenValue,
+        accessTokenTtl;
 
     async.waterfall([
         // Check user decision
@@ -23,10 +24,21 @@ module.exports = function(req, res, client, scope, user, redirectUri) {
                 cb();
             }
         },
+        //Get accessToken ttl based on the req and the client
+        function(cb) {
+            req.oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+                if(err)
+                    cb(new error.serverError('Failed to call accessToken::getTTL method'));
+                else {
+                    accessTokenTtl = ttl;
+                    cb();
+                }
+            });
+        },
         // Generate new accessToken and save it
         function(cb) {
             accessTokenValue = req.oauth2.model.accessToken.generateToken();
-            req.oauth2.model.accessToken.save(req, accessTokenValue, req.oauth2.model.user.getId(user), req.oauth2.model.client.getId(client), scope, req.oauth2.model.accessToken.ttl, function(err) {
+            req.oauth2.model.accessToken.save(req, accessTokenValue, req.oauth2.model.user.getId(user), req.oauth2.model.client.getId(client), scope, accessTokenTtl, function(err) {
                 if (err)
                     cb(new error.serverError('Failed to call accessToken::save method'));
                 else {
@@ -38,10 +50,14 @@ module.exports = function(req, res, client, scope, user, redirectUri) {
     ],
     function(err) {
         if (err) response.error(req, res, err, redirectUri);
-        else response.data(req, res, {
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    req.oauth2.model.accessToken.ttl
-        }, redirectUri, true);
+        else {
+            var token = {
+                token_type: "bearer",
+                access_token: accessTokenValue
+            };
+            if(accessTokenTtl > 0)
+                token.expires_in = accessTokenTtl;
+            response.data(req, res, token, redirectUri, true);
+        }
     });
 };

--- a/lib/controller/token/authorizationCode.js
+++ b/lib/controller/token/authorizationCode.js
@@ -7,7 +7,8 @@ module.exports = function(req, oauth2, client, sCode, redirectUri, pCb) {
     // Define variables
     var code,
         refreshTokenValue,
-        accessTokenValue;
+        accessTokenValue,
+        accessTokenTtl;
 
     async.waterfall([
         // Fetch code
@@ -52,10 +53,21 @@ module.exports = function(req, oauth2, client, sCode, redirectUri, pCb) {
                 }
             });
         },
+        //Get accessToken ttl based on the req and the client
+        function(cb) {
+            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+                if(err)
+                    cb(new error.serverError('Failed to call accessToken::getTTL method'));
+                else {
+                    accessTokenTtl = ttl;
+                    cb();
+                }
+            });
+        },
         // Generate new accessToken and save it
         function(cb) {
             accessTokenValue = oauth2.model.accessToken.generateToken();
-            oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.code.getUserId(code), oauth2.model.code.getClientId(code), oauth2.model.code.getScope(code), oauth2.model.accessToken.ttl, function(err) {
+            oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.code.getUserId(code), oauth2.model.code.getClientId(code), oauth2.model.code.getScope(code), accessTokenTtl, function(err) {
                 if (err)
                     cb(new error.serverError('Failed to call accessToken::save method'));
                 else {
@@ -77,12 +89,16 @@ module.exports = function(req, oauth2, client, sCode, redirectUri, pCb) {
         }
     ], function(err) {
         if (err) pCb(err);
-        else pCb(null, {
-            refresh_token: refreshTokenValue,
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    oauth2.model.accessToken.ttl
-        });
+        else {
+            var token = {
+                refresh_token: refreshTokenValue,
+                token_type: "bearer",
+                access_token: accessTokenValue
+            };
+            if(accessTokenTtl > 0)
+                token.expires_in = accessTokenTtl;
+            pCb(null, token);
+        }
     });
 
 };

--- a/lib/controller/token/clientCredentials.js
+++ b/lib/controller/token/clientCredentials.js
@@ -7,7 +7,8 @@ module.exports = function(req, oauth2, client, scope, pCb) {
 
     // Define variables
     var scope,
-        accessTokenValue;
+        accessTokenValue,
+        accessTokenTtl;
 
     async.waterfall([
         // Parse and check scope against supported and client available scopes
@@ -21,10 +22,21 @@ module.exports = function(req, oauth2, client, scope, pCb) {
                 cb();
             }
         },
+        //Get accessToken ttl based on the req and the client
+        function(cb) {
+            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+                if(err)
+                    cb(new error.serverError('Failed to call accessToken::getTTL method'));
+                else {
+                    accessTokenTtl = ttl;
+                    cb();
+                }
+            });
+        },
         // Generate new accessToken and save it
         function(cb) {
             accessTokenValue = oauth2.model.accessToken.generateToken();
-            oauth2.model.accessToken.save(req, accessTokenValue, null, oauth2.model.client.getId(client), scope, oauth2.model.accessToken.ttl, function(err) {
+            oauth2.model.accessToken.save(req, accessTokenValue, null, oauth2.model.client.getId(client), scope, accessTokenTtl, function(err) {
                 if (err)
                     cb(new error.serverError('Failed to call accessToken::save method'));
                 else {
@@ -36,10 +48,14 @@ module.exports = function(req, oauth2, client, scope, pCb) {
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, {
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    oauth2.model.accessToken.ttl
-        });
+        else {
+            var token = {
+                token_type: "bearer",
+                access_token: accessTokenValue
+            };
+            if(accessTokenTtl > 0)
+                token.expires_in = accessTokenTtl;
+            pCb(null, token);
+        }
     });
 };

--- a/lib/controller/token/password.js
+++ b/lib/controller/token/password.js
@@ -9,7 +9,8 @@ module.exports = function(req, oauth2, client, username, password, scope, pCb) {
     var user,
         scope,
         refreshTokenValue,
-        accessTokenValue;
+        accessTokenValue,
+        accessTokenTtl;
 
     async.waterfall([
         // Check username and password parameters
@@ -78,10 +79,21 @@ module.exports = function(req, oauth2, client, username, password, scope, pCb) {
                 }
             });
         },
+        //Get accessToken ttl based on the req and the client
+        function(cb) {
+            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+                if(err)
+                    cb(new error.serverError('Failed to call accessToken::getTTL method'));
+                else {
+                    accessTokenTtl = ttl;
+                    cb();
+                }
+            });
+        },
         // Generate new accessToken and save it
         function(cb) {
             accessTokenValue = oauth2.model.accessToken.generateToken();
-            oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.user.getId(user), oauth2.model.client.getId(client), scope, oauth2.model.accessToken.ttl, function(err) {
+            oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.user.getId(user), oauth2.model.client.getId(client), scope, accessTokenTtl, function(err) {
                 if (err)
                     cb(new error.serverError('Failed to call accessToken::save method'));
                 else {
@@ -93,11 +105,15 @@ module.exports = function(req, oauth2, client, username, password, scope, pCb) {
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, {
-            refresh_token: refreshTokenValue,
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    oauth2.model.accessToken.ttl
-        });
+        else {
+            var token = {
+                refresh_token: refreshTokenValue,
+                token_type: "bearer",
+                access_token: accessTokenValue
+            };
+            if(accessTokenTtl > 0)
+                token.expires_in = accessTokenTtl;
+            pCb(null, token);
+        }
     });
 };

--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -7,7 +7,8 @@ module.exports = function(req, oauth2, client, refresh_token, scope, pCb) {
     var user,
         refreshToken,
         accessToken,
-        accessTokenValue;
+        accessTokenValue,
+        accessTokenTtl;
 
     async.waterfall([
         // Check refresh_token parameter
@@ -65,6 +66,17 @@ module.exports = function(req, oauth2, client, refresh_token, scope, pCb) {
                 };
             });
         },
+        //Get accessToken ttl based on the req and the client
+        function(cb) {
+            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+                if(err)
+                    cb(new error.serverError('Failed to call accessToken::getTTL method'));
+                else {
+                    accessTokenTtl = ttl;
+                    cb();
+                }
+            });
+        },
         // Issue new one (if needed)
         function(cb) {
             // No need if it already exists and valid
@@ -74,7 +86,7 @@ module.exports = function(req, oauth2, client, refresh_token, scope, pCb) {
             }
             else {
                 accessTokenValue = oauth2.model.accessToken.generateToken();
-                oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.user.getId(user), oauth2.model.client.getId(client), oauth2.model.refreshToken.getScope(refreshToken), oauth2.model.accessToken.ttl, function(err) {
+                oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.user.getId(user), oauth2.model.client.getId(client), oauth2.model.refreshToken.getScope(refreshToken), accessTokenTtl, function(err) {
                     if (err)
                         cb(new error.serverError('Failed to call accessToken::save method'));
                     else {
@@ -102,11 +114,14 @@ module.exports = function(req, oauth2, client, refresh_token, scope, pCb) {
     ],
     function(err) {
         if (err) pCb(err);
-        else pCb(null, {
-            // @todo: add renew refresh token strategy
-            token_type:    "bearer",
-            access_token:  accessTokenValue,
-            expires_in:    oauth2.model.accessToken.ttl
-        });
+        else {
+            var token = {
+                token_type: "bearer",
+                access_token: accessTokenValue
+            };
+            if(accessTokenTtl > 0)
+                token.expires_in = accessTokenTtl;
+            pCb(null, token);
+        }
     });
 };

--- a/lib/model/accessToken.js
+++ b/lib/model/accessToken.js
@@ -57,6 +57,18 @@ module.exports.generateToken = function() {
     return crypto.randomBytes(32).toString('hex');
 };
 
+
+/**
+ * Check if accessToken is valid and not expired
+ *
+ * @param req {Object} request object
+ * @param client {Object} client object
+ */
+module.exports.getTTL = function(req, client, cb) {
+  throw new error.serverError('accessToken model method "getTTL" is not implemented');
+};
+
+
 /**
  * Check if accessToken is valid and not expired
  *

--- a/test/server/model/memory/oauth2/accessToken.js
+++ b/test/server/model/memory/oauth2/accessToken.js
@@ -28,3 +28,6 @@ module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
     cb();
 };
 
+module.exports.getTTL = function(req, client, cb) {
+  cb(null, 3600);
+};

--- a/test/server/model/memory/oauth2/client.js
+++ b/test/server/model/memory/oauth2/client.js
@@ -18,3 +18,7 @@ module.exports.fetchById = function(clientId, cb) {
 module.exports.checkSecret = function(client, secret) {
     return (client.secret == secret);
 };
+
+module.exports.needDecisionConfirmation = function(client, secret) {
+  return true;
+};

--- a/test/server/model/memory/oauth2/refreshToken.js
+++ b/test/server/model/memory/oauth2/refreshToken.js
@@ -24,3 +24,7 @@ module.exports.save = function(req, token, userId, clientId, scope, cb) {
     refreshTokens.push(obj);
     cb(null, obj);
 };
+
+module.exports.refresh = function(req, refreshToken, userId, clientId, cb) {
+    cb(null);
+};

--- a/test/server/model/redis/oauth2/accessToken.js
+++ b/test/server/model/redis/oauth2/accessToken.js
@@ -50,3 +50,7 @@ module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
     });
 };
 
+module.exports.getTTL = function(req, client, cb) {
+  cb(null, 3600);
+};
+

--- a/test/server/model/redis/oauth2/client.js
+++ b/test/server/model/redis/oauth2/client.js
@@ -35,3 +35,7 @@ module.exports.fetchById = function(clientId, cb) {
 module.exports.checkSecret = function(client, secret) {
     return (client.secret == secret);
 };
+
+module.exports.needDecisionConfirmation = function(client, secret) {
+  return true;
+};

--- a/test/server/model/redis/oauth2/refreshToken.js
+++ b/test/server/model/redis/oauth2/refreshToken.js
@@ -40,3 +40,6 @@ module.exports.removeByUserIdClientId = function(userId, clientId, cb) {
     cb();
 };
 
+module.exports.refresh = function(req, refreshToken, userId, clientId, cb) {
+  cb(null);
+};

--- a/test/server/oauth20.js
+++ b/test/server/oauth20.js
@@ -15,6 +15,7 @@ module.exports = function(type) {
     obj.model.client.getRedirectUri = model.client.getRedirectUri;
     obj.model.client.fetchById = model.client.fetchById;
     obj.model.client.checkSecret = model.client.checkSecret;
+    obj.model.client.needDecisionConfirmation = model.client.needDecisionConfirmation;
 
     // User
     obj.model.user.getId = model.user.getId;
@@ -29,11 +30,13 @@ module.exports = function(type) {
     obj.model.refreshToken.fetchByToken = model.refreshToken.fetchByToken;
     obj.model.refreshToken.removeByUserIdClientId = model.refreshToken.removeByUserIdClientId;
     obj.model.refreshToken.save = model.refreshToken.save;
+    obj.model.refreshToken.refresh = model.refreshToken.refresh;
 
     // Access token
     obj.model.accessToken.getToken = model.accessToken.getToken;
     obj.model.accessToken.fetchByToken = model.accessToken.fetchByToken;
     obj.model.accessToken.checkTTL = model.accessToken.checkTTL;
+    obj.model.accessToken.getTTL = model.accessToken.getTTL;
     obj.model.accessToken.fetchByUserIdClientId = model.accessToken.fetchByUserIdClientId;
     obj.model.accessToken.save = model.accessToken.save;
 
@@ -51,7 +54,7 @@ module.exports = function(type) {
         var html = [
             'Currently your are logged with id = ' + req.oauth2.model.user.getId(user),
             'Client with id ' + req.oauth2.model.client.getId(client) + ' asks for access',
-            'Scope asked ' + scope.join(),
+            /*'Scope asked ' + scope.join(),*/
             '<form method="POST">',
             '<input type="hidden" name="decision" value="1" />',
             '<input type="submit" value="Authorize" />',


### PR DESCRIPTION
The ttl for the access token is not a common value but is requested for each client & req.
Also, only a valid and positive ttl is added in the expires_in hash of the access_token. If the ttl is negative (to indicate infinite timeout), the expires_in is not populated in the token hash.

Also, fixes broken test cases.
