### PR TITLE
BE-357: Update Kaybus node-oauth20-provider to pass userId in getTTL method

### DIFF
--- a/lib/controller/authorization/implicit.js
+++ b/lib/controller/authorization/implicit.js
@@ -26,7 +26,7 @@ module.exports = function(req, res, client, scope, user, redirectUri) {
         },
         //Get accessToken ttl based on the req and the client
         function(cb) {
-            req.oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+            req.oauth2.model.accessToken.getTTL(req, user, client, function(err, ttl) {
                 if(err)
                     cb(new error.serverError('Failed to call accessToken::getTTL method'));
                 else {

--- a/lib/controller/token/authorizationCode.js
+++ b/lib/controller/token/authorizationCode.js
@@ -55,12 +55,18 @@ module.exports = function(req, oauth2, client, sCode, redirectUri, pCb) {
         },
         //Get accessToken ttl based on the req and the client
         function(cb) {
-            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
-                if(err)
-                    cb(new error.serverError('Failed to call accessToken::getTTL method'));
+            oauth2.model.user.fetchById(req, oauth2.model.code.getUserId(code), function(err, user) {
+                if (err)
+                    cb(new error.serverError('Failed to get user from code value'));
                 else {
-                    accessTokenTtl = ttl;
-                    cb();
+                    oauth2.model.accessToken.getTTL(req, user, client, function (err, ttl) {
+                        if (err)
+                            cb(new error.serverError('Failed to call accessToken::getTTL method'));
+                        else {
+                            accessTokenTtl = ttl;
+                            cb();
+                        }
+                    });
                 }
             });
         },

--- a/lib/controller/token/clientCredentials.js
+++ b/lib/controller/token/clientCredentials.js
@@ -24,7 +24,7 @@ module.exports = function(req, oauth2, client, scope, pCb) {
         },
         //Get accessToken ttl based on the req and the client
         function(cb) {
-            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+            oauth2.model.accessToken.getTTL(req, null, client, function(err, ttl) {
                 if(err)
                     cb(new error.serverError('Failed to call accessToken::getTTL method'));
                 else {

--- a/lib/controller/token/password.js
+++ b/lib/controller/token/password.js
@@ -81,7 +81,7 @@ module.exports = function(req, oauth2, client, username, password, scope, pCb) {
         },
         //Get accessToken ttl based on the req and the client
         function(cb) {
-            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+            oauth2.model.accessToken.getTTL(req, user, client, function(err, ttl) {
                 if(err)
                     cb(new error.serverError('Failed to call accessToken::getTTL method'));
                 else {

--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -68,7 +68,7 @@ module.exports = function(req, oauth2, client, refresh_token, scope, pCb) {
         },
         //Get accessToken ttl based on the req and the client
         function(cb) {
-            oauth2.model.accessToken.getTTL(req, client, function(err, ttl) {
+            oauth2.model.accessToken.getTTL(req, user, client, function(err, ttl) {
                 if(err)
                     cb(new error.serverError('Failed to call accessToken::getTTL method'));
                 else {

--- a/lib/model/accessToken.js
+++ b/lib/model/accessToken.js
@@ -64,7 +64,7 @@ module.exports.generateToken = function() {
  * @param req {Object} request object
  * @param client {Object} client object
  */
-module.exports.getTTL = function(req, client, cb) {
+module.exports.getTTL = function(req, user, client, cb) {
   throw new error.serverError('accessToken model method "getTTL" is not implemented');
 };
 

--- a/test/server/model/memory/oauth2/accessToken.js
+++ b/test/server/model/memory/oauth2/accessToken.js
@@ -28,6 +28,6 @@ module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
     cb();
 };
 
-module.exports.getTTL = function(req, client, cb) {
+module.exports.getTTL = function(req, user, client, cb) {
   cb(null, 3600);
 };

--- a/test/server/model/redis/oauth2/accessToken.js
+++ b/test/server/model/redis/oauth2/accessToken.js
@@ -50,7 +50,7 @@ module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
     });
 };
 
-module.exports.getTTL = function(req, client, cb) {
+module.exports.getTTL = function(req, user, client, cb) {
   cb(null, 3600);
 };
 


### PR DESCRIPTION
This addition of "user" in the getTTL method signature is needed as the timeout period is fetched from tenant preferances based on the user's accountId.