### PR TITLE
feature/KB-5508: Adding support to pass the client credentials in body params.

### DIFF
--- a/lib/controller/token.js
+++ b/lib/controller/token.js
@@ -23,24 +23,31 @@ module.exports = function(req, res) {
     async.waterfall([
         // Parse client credentials from BasicAuth header
         function(cb) {
-            if (!req.headers || !req.headers.authorization)
-                return cb(new error.invalidRequest('No authorization header passed'));
+            if (!req.headers || !req.headers.authorization || !req.body.clientId || !req.body.client_secret)
+                return cb(new error.invalidRequest('No authorization header or body params passed'));
 
-            var pieces = req.headers.authorization.split(' ', 2);
-            if (!pieces || pieces.length !== 2)
-                return cb(new error.invalidRequest('Authorization header is corrupted'));
+            if(req.headers.authorization) {
+                var pieces = req.headers.authorization.split(' ', 2);
+                if (!pieces || pieces.length !== 2)
+                    return cb(new error.invalidRequest('Authorization header is corrupted'));
 
-            if (pieces[0] !== 'Basic')
-                return cb(new error.invalidRequest('Unsupported authorization method: ', pieces[0]));
+                if (pieces[0] !== 'Basic')
+                    return cb(new error.invalidRequest('Unsupported authorization method: ', pieces[0]));
 
-            pieces = new Buffer(pieces[1], 'base64').toString('ascii').split(':', 2);
-            if (!pieces || pieces.length !== 2)
-                return cb(new error.invalidRequest('Authorization header has corrupted data'));
+                pieces = new Buffer(pieces[1], 'base64').toString('ascii').split(':', 2);
+                if (!pieces || pieces.length !== 2)
+                    return cb(new error.invalidRequest('Authorization header has corrupted data'));
 
-            clientId = pieces[0];
-            clientSecret = pieces[1];
-            req.oauth2.logger.debug('Client credentials parsed from basic auth header: ', clientId, clientSecret);
-            cb();
+                clientId = pieces[0];
+                clientSecret = pieces[1];
+                req.oauth2.logger.debug('Client credentials parsed from basic auth header: ', clientId, clientSecret);
+                cb();
+            } else {
+                clientId = req.body.client_id;
+                clientSecret = req.body.client_secret;
+                req.oauth2.logger.debug('Client credentials from body params: ', clientId, clientSecret);
+                cb();
+            }
         },
         // Check grant type for server support
         function(cb) {

--- a/lib/controller/token.js
+++ b/lib/controller/token.js
@@ -23,7 +23,7 @@ module.exports = function(req, res) {
     async.waterfall([
         // Parse client credentials from BasicAuth header
         function(cb) {
-            if (!req.headers || !req.headers.authorization || !req.body.clientId || !req.body.client_secret)
+            if ((!req.headers || !req.headers.authorization) && (!req.body.client_id || !req.body.client_secret))
                 return cb(new error.invalidRequest('No authorization header or body params passed'));
 
             if(req.headers.authorization) {


### PR DESCRIPTION
This fix is necessary as the exisiting mobile client passes the clientId and clientSecret in the body params instead of inserting in the header with Basic Auth.

Reference to rfc 6749 related to clientId and clientSecret Basic Auth encoding:
https://tools.ietf.org/html/rfc6749\#section-2.3.1
As per the rfc, support for Basic Auth encoding of the clientId and clientSecret in the header is compulsory.
Support for clientId and clientSecret in the body params is optional.

Since it being an optional part of the standard it was not implemented.

But without this fix, the mobile client login is broken. Also, force updating all users to the updated mobile client is not feasible.
Hence, this fix in needed.