### PR TITLE
feature/IN-776_new_fix: Support for multiple logins with same credentials at same time

### DIFF
--- a/lib/controller/token/authorizationCode.js
+++ b/lib/controller/token/authorizationCode.js
@@ -29,18 +29,6 @@ module.exports = function(req, oauth2, client, sCode, redirectUri, pCb) {
                 }
             });
         },
-        // @todo: clarify. Check redirectUri? Weird standard, why should we?
-        // Remove old refreshToken (if exists) with userId-clientId pair
-        function(cb) {
-            oauth2.model.refreshToken.removeByUserIdClientId(oauth2.model.code.getUserId(code), oauth2.model.code.getClientId(code), function(err) {
-                if (err)
-                    cb(new error.serverError('Failed to call refreshToken::removeByUserIdClientId method'));
-                else {
-                    oauth2.logger.debug('Refresh token removed');
-                    cb();
-                }
-            });
-        },
         // Generate new refreshToken and save it
         function(cb) {
             refreshTokenValue = oauth2.model.refreshToken.generateToken();

--- a/lib/controller/token/password.js
+++ b/lib/controller/token/password.js
@@ -56,17 +56,6 @@ module.exports = function(req, oauth2, client, username, password, scope, pCb) {
                 }
             });
         },
-        // Remove old refreshToken (if exists) with userId-clientId pair
-        function(cb) {
-            oauth2.model.refreshToken.removeByUserIdClientId(oauth2.model.user.getId(user), oauth2.model.client.getId(client), function(err) {
-                if (err)
-                    cb(new error.serverError('Failed to call refreshToken::removeByUserIdClientId method'));
-                else {
-                    oauth2.logger.debug('Refresh token removed');
-                    cb();
-                }
-            });
-        },
         // Generate new refreshToken and save it
         function(cb) {
             refreshTokenValue = oauth2.model.refreshToken.generateToken();

--- a/lib/controller/token/refreshToken.js
+++ b/lib/controller/token/refreshToken.js
@@ -53,19 +53,6 @@ module.exports = function(req, oauth2, client, refresh_token, scope, pCb) {
                 }
             });
         },
-        // Fetch issued access token (if it is already created and still active)
-        function(cb) {
-            oauth2.model.accessToken.fetchByUserIdClientId(oauth2.model.user.getId(user), oauth2.model.client.getId(client), function(err, obj) {
-                if (err)
-                    cb(new error.serverError('Failed to call accessToken::fetchByUserIdClientId'));
-                else if (!obj) cb();
-                else {
-                    accessToken = obj;
-                    oauth2.logger.debug('Fetched issued accessToken: ', obj);
-                    cb();
-                };
-            });
-        },
         //Get accessToken ttl based on the req and the client
         function(cb) {
             oauth2.model.accessToken.getTTL(req, user, client, function(err, ttl) {
@@ -77,24 +64,18 @@ module.exports = function(req, oauth2, client, refresh_token, scope, pCb) {
                 }
             });
         },
-        // Issue new one (if needed)
+        // Issue new one.
         function(cb) {
-            // No need if it already exists and valid
-            if (accessToken) {
-                accessTokenValue = oauth2.model.accessToken.getToken(accessToken);
-                cb();
-            }
-            else {
-                accessTokenValue = oauth2.model.accessToken.generateToken();
-                oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.user.getId(user), oauth2.model.client.getId(client), oauth2.model.refreshToken.getScope(refreshToken), accessTokenTtl, function(err) {
-                    if (err)
-                        cb(new error.serverError('Failed to call accessToken::save method'));
-                    else {
-                        oauth2.logger.debug('Access token saved: ', accessTokenValue);
-                        cb();
-                    }
-                });
-            }
+            /*To support multiple login, we are always issuing new access token in the refresh token flow.*/
+            accessTokenValue = oauth2.model.accessToken.generateToken();
+            oauth2.model.accessToken.save(req, accessTokenValue, oauth2.model.user.getId(user), oauth2.model.client.getId(client), oauth2.model.refreshToken.getScope(refreshToken), accessTokenTtl, function(err) {
+                if (err)
+                    cb(new error.serverError('Failed to call accessToken::save method'));
+                else {
+                    oauth2.logger.debug('Access token saved: ', accessTokenValue);
+                    cb();
+                }
+            });
         },
         //Refresh the refreshToken
         function(cb) {

--- a/lib/model/accessToken.js
+++ b/lib/model/accessToken.js
@@ -39,18 +39,6 @@ module.exports.fetchByToken = function(token, cb) {
 };
 
 /**
- * Fetches accessToken object by userId-clientId pair
- * Should be implemented with server logic
- *
- * @param userId {String} Unique identifier
- * @param clientId {String} Unique identifier
- * @param cb {Function} Function callback ->(error, object)
- */
-module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
-    throw new error.serverError('accessToken model method "fetchByUserIdClientId" is not implemented');
-};
-
-/**
  * Generates token
  */
 module.exports.generateToken = function() {

--- a/lib/model/refreshToken.js
+++ b/lib/model/refreshToken.js
@@ -67,18 +67,6 @@ module.exports.fetchByToken = function(token, cb) {
 };
 
 /**
- * Removes refreshToken (revokes) for the client-user pair
- * Should be implemented with server logic
- *
- * @param userId {String} Unique identifier
- * @param clientId {String} Unique identifier
- * @param cb {Function} Function callback ->(error)
- */
-module.exports.removeByUserIdClientId = function(userId, clientId, cb) {
-    throw new error.serverError('RefreshToken model method "removeByUserIdClientId" is not implemented');
-};
-
-/**
  * Generates token
  */
 module.exports.generateToken = function() {

--- a/test/server/model/memory/oauth2/accessToken.js
+++ b/test/server/model/memory/oauth2/accessToken.js
@@ -21,13 +21,6 @@ module.exports.checkTTL = function(accessToken) {
     return (accessToken.ttl > new Date().getTime());
 };
 
-module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
-    for (var i in accessTokens) {
-        if (accessTokens[i].userId == userId && accessTokens[i].clientId == clientId) return cb(null, accessTokens[i]);
-    };
-    cb();
-};
-
 module.exports.getTTL = function(req, user, client, cb) {
   cb(null, 3600);
 };

--- a/test/server/model/memory/oauth2/refreshToken.js
+++ b/test/server/model/memory/oauth2/refreshToken.js
@@ -11,14 +11,6 @@ module.exports.fetchByToken = function(token, cb) {
     cb(null, null);
 };
 
-module.exports.removeByUserIdClientId = function(userId, clientId, cb) {
-    for (var i in refreshTokens) {
-        if (refreshTokens[i].userId == userId && refreshTokens[i].clientId == clientId)
-            refreshTokens.splice(i, 1);
-    };
-    cb();
-};
-
 module.exports.save = function(req, token, userId, clientId, scope, cb) {
     var obj = {token: token, userId: userId, clientId: clientId, scope: scope};
     refreshTokens.push(obj);

--- a/test/server/model/redis/oauth2/accessToken.js
+++ b/test/server/model/redis/oauth2/accessToken.js
@@ -4,8 +4,7 @@ var
 
 // SOME KEY CONSTANTS
 var KEY = {
-    ACCESS_TOKEN:      'accessToken:%s',
-    USER_CLIENT_TOKEN: 'userId:%s:clientId:%s'
+    ACCESS_TOKEN:      'accessToken:%s'
 };
 
 module.exports.KEY = KEY;
@@ -18,7 +17,6 @@ module.exports.save = function(req, token, userId, clientId, scope, ttl, cb) {
     var ttl = new Date().getTime() + ttl * 1000;
     var obj = {token: token, userId: userId, clientId: clientId, scope: scope};
     redis.setex(util.format(KEY.ACCESS_TOKEN, token), ttl, JSON.stringify(obj), cb);
-    redis.setex(util.format(KEY.USER_CLIENT_TOKEN, userId, clientId), ttl, token, function() {});
 };
 
 var fetchByToken = function(token, cb) {
@@ -41,13 +39,6 @@ module.exports.fetchByToken = fetchByToken;
 // No need to check expiry due to Redis TTL
 module.exports.checkTTL = function(accessToken) {
     return true;
-};
-
-module.exports.fetchByUserIdClientId = function(userId, clientId, cb) {
-    redis.get(util.format(KEY.USER_CLIENT_TOKEN, userId, clientId), function(err, token) {
-        if (err) cb(err);
-        else fetchByToken(token, cb);
-    });
 };
 
 module.exports.getTTL = function(req, user, client, cb) {

--- a/test/server/model/redis/oauth2/refreshToken.js
+++ b/test/server/model/redis/oauth2/refreshToken.js
@@ -35,11 +35,6 @@ module.exports.fetchByToken = function(token, cb) {
     });
 };
 
-// @todo: remove old refreshTokens
-module.exports.removeByUserIdClientId = function(userId, clientId, cb) {
-    cb();
-};
-
 module.exports.refresh = function(req, refreshToken, userId, clientId, cb) {
   cb(null);
 };

--- a/test/server/oauth20.js
+++ b/test/server/oauth20.js
@@ -28,7 +28,6 @@ module.exports = function(type) {
     obj.model.refreshToken.getUserId = model.refreshToken.getUserId;
     obj.model.refreshToken.getClientId = model.refreshToken.getUserId;
     obj.model.refreshToken.fetchByToken = model.refreshToken.fetchByToken;
-    obj.model.refreshToken.removeByUserIdClientId = model.refreshToken.removeByUserIdClientId;
     obj.model.refreshToken.save = model.refreshToken.save;
     obj.model.refreshToken.refresh = model.refreshToken.refresh;
 
@@ -37,7 +36,6 @@ module.exports = function(type) {
     obj.model.accessToken.fetchByToken = model.accessToken.fetchByToken;
     obj.model.accessToken.checkTTL = model.accessToken.checkTTL;
     obj.model.accessToken.getTTL = model.accessToken.getTTL;
-    obj.model.accessToken.fetchByUserIdClientId = model.accessToken.fetchByUserIdClientId;
     obj.model.accessToken.save = model.accessToken.save;
 
     // Code


### PR DESCRIPTION
To add support for this feature, the mecahnism of saving & then retrieving the tokens (access token / refresh token) based on the user_id and client_id has been removed.
The reason being, if we supported that we can never store more than one access & refresh tokens for the same user id and client id.
Since, the access & refresh tokens are saved with expiring nature, saving more than one is not a risk.
Also, the standard doesnt the need to store only one at any point.

Signed-off-by: Sumukh Avadhani <sumukh.avadhani@kaybus.com>

No change from previous PR for IN-776 which was reverted. The problem was that a change in Rails had not been merged.