### PR TITLE
EP-2607 Restrict client credentials oauth to specific tenant

### DIFF
--- a/lib/controller/token.js
+++ b/lib/controller/token.js
@@ -65,6 +65,8 @@ module.exports = function(req, res) {
                     cb(new error.serverError('Failed to call client::fetchById method'));
                 else if (!obj)
                     cb(new error.invalidClient('Client not found'));
+                else if (!req.oauth2.model.client.checkTenantUrl(req, obj))
+                    cb(new error.invalidClient('Invalid client'));
                 else if (!req.oauth2.model.client.checkSecret(obj, clientSecret))
                     cb(new error.invalidClient('Wrong client secret provided'));
                 else {

--- a/lib/model/client.js
+++ b/lib/model/client.js
@@ -73,6 +73,10 @@ module.exports.checkSecret = function(client, secret) {
     throw new error.serverError('Client model method "checkSecret" is not implemented');
 };
 
+module.exports.checkTenantUrl = function(req, obj) {
+    throw new error.serverError('Client model method "checkTenantUrl" is not implemented');
+};
+
 /**
  * Checks grant type permission for the client
  * Default: do not check it

--- a/test/password.js
+++ b/test/password.js
@@ -9,6 +9,14 @@ describe('Password Grant Type ',function() {
         refreshToken,
         accessToken;
 
+    it('POST /token with grant_type="password" should throw error when tenant_url dont match', function(done) {
+        request(app)
+            .post('/token')
+            .set('Authorization', 'Basic ' + new Buffer(data.clients[2].id + ':' + data.clients[2].secret, 'ascii').toString('base64'))
+            .send({grant_type: 'password', username: data.users[0].username, password: data.users[0].password})
+            .expect(401, '{"error":"invalid_client","error_description":"Invalid client"}', done);
+    });
+
     it('POST /token with grant_type="password" expect token', function(done) {
         request(app)
             .post('/token')
@@ -23,7 +31,7 @@ describe('Password Grant Type ',function() {
             });
     });
 
-    it('POST /token with grant_type="refresh_token" expect same accessToken', function(done) {
+    it('POST /token with grant_type="refresh_token" expect new accessToken always', function(done) {
         request(app)
             .post('/token')
             .set('Authorization', 'Basic ' + new Buffer(data.clients[0].id + ':' + data.clients[0].secret, 'ascii').toString('base64'))
@@ -31,7 +39,7 @@ describe('Password Grant Type ',function() {
             .expect(200, /access_token/)
             .end(function(err, res) {
                 if (err) return done(err);
-                if (accessToken != res.body.access_token) return done(new Error('AccessToken strings do not match'));
+                if (accessToken == res.body.access_token) return done(new Error('AccessToken should be new always'));
                 done();
             });
     });

--- a/test/server/model/data.js
+++ b/test/server/model/data.js
@@ -12,14 +12,24 @@ module.exports = {
             id:             'client1.id',
             name:           'client1.name',
             secret:         'client1.secret',
-            redirectUri:    'http://example.org/oauth2'
+            redirectUri:    'http://example.org/oauth2',
+            tenant_url: "127.0.0.1"
         },
         {
             id:             'client2.id',
             name:           'client2.name',
             secret:         'client2.Secret',
-            redirectUri:    'http://example.org/oauth2'
+            redirectUri:    'http://example.org/oauth2',
+            tenant_url: "all"
+        },
+        {
+            id:             'client3.id',
+            name:           'client3.name',
+            secret:         'client3.Secret',
+            redirectUri:    'http://example.org/oauth2',
+            tenant_url: "test.kaybus.com"
         }
+
     ],
     codes: [],
     accessTokens: [],

--- a/test/server/model/memory/oauth2/client.js
+++ b/test/server/model/memory/oauth2/client.js
@@ -19,6 +19,10 @@ module.exports.checkSecret = function(client, secret) {
     return (client.secret == secret);
 };
 
+exports.checkTenantUrl = function(req, obj) {
+  return [req.hostname, "all"].indexOf(obj.tenant_url) > -1;
+};
+
 module.exports.needDecisionConfirmation = function(client, secret) {
   return true;
 };

--- a/test/server/model/memory/oauth2/refreshToken.js
+++ b/test/server/model/memory/oauth2/refreshToken.js
@@ -17,6 +17,10 @@ module.exports.save = function(req, token, userId, clientId, scope, cb) {
     cb(null, obj);
 };
 
+module.exports.getScope = function(refreshToken) {
+    return [];
+};
+
 module.exports.refresh = function(req, refreshToken, userId, clientId, cb) {
     cb(null);
 };

--- a/test/server/model/redis/oauth2/client.js
+++ b/test/server/model/redis/oauth2/client.js
@@ -36,6 +36,10 @@ module.exports.checkSecret = function(client, secret) {
     return (client.secret == secret);
 };
 
+exports.checkTenantUrl = function(req, obj) {
+  return [req.hostname, "all"].indexOf(obj.tenant_url) > -1;
+};
+
 module.exports.needDecisionConfirmation = function(client, secret) {
   return true;
 };

--- a/test/server/oauth20.js
+++ b/test/server/oauth20.js
@@ -15,6 +15,7 @@ module.exports = function(type) {
     obj.model.client.getRedirectUri = model.client.getRedirectUri;
     obj.model.client.fetchById = model.client.fetchById;
     obj.model.client.checkSecret = model.client.checkSecret;
+    obj.model.client.checkTenantUrl = model.client.checkTenantUrl;
     obj.model.client.needDecisionConfirmation = model.client.needDecisionConfirmation;
 
     // User
@@ -29,6 +30,7 @@ module.exports = function(type) {
     obj.model.refreshToken.getClientId = model.refreshToken.getUserId;
     obj.model.refreshToken.fetchByToken = model.refreshToken.fetchByToken;
     obj.model.refreshToken.save = model.refreshToken.save;
+    obj.model.refreshToken.getScope = model.refreshToken.getScope;
     obj.model.refreshToken.refresh = model.refreshToken.refresh;
 
     // Access token


### PR DESCRIPTION
In current oauth flow client_id and client_secret are common to all the tenants. This fix allows to restrict to one single tenant
